### PR TITLE
Fix Leftover Handling to Ensure Consistent Batch Sizes and Resolutions

### DIFF
--- a/bucketmanager.py
+++ b/bucketmanager.py
@@ -220,6 +220,10 @@ class BucketManager:
                 assert False, "Chosen bucket ID not found in epoch or leftovers"
 
         if self.debug:
+            print(f"bucket probs: " + ", ".join(map(lambda x: f"{x:.2f}", list(bucket_probs*100))))
+            print(f"chosen id: {chosen_id}")
+            print(f"batch data: {batch_data}")
+            print(f"resolution: {resolution}")
             timer = time.perf_counter() - timer
             print(f"get_batch: {timer:.5f}s")
 

--- a/bucketmanager.py
+++ b/bucketmanager.py
@@ -220,11 +220,11 @@ class BucketManager:
                 assert False, "Chosen bucket ID not found in epoch or leftovers"
 
         if self.debug:
+            timer = time.perf_counter() - timer
             print(f"bucket probs: " + ", ".join(map(lambda x: f"{x:.2f}", list(bucket_probs*100))))
             print(f"chosen id: {chosen_id}")
             print(f"batch data: {batch_data}")
             print(f"resolution: {resolution}")
-            timer = time.perf_counter() - timer
             print(f"get_batch: {timer:.5f}s")
 
         self.batch_delivered += 1

--- a/bucketmanager.py
+++ b/bucketmanager.py
@@ -10,7 +10,7 @@ def get_prng(seed):
 
 class BucketManager:
     def __init__(self, bucket_file, valid_ids=None, max_size=(768,512), divisible=64, step_size=8, min_dim=256, base_res=(512,512), bsz=64, world_size=1, global_rank=0, max_ar_error=4, seed=42, dim_limit=1024, debug=False):
-        with open(bucket_file, "r") as fh:
+        with open(bucket_file, "rb") as fh:
             self.res_map = json.load(fh)
         if valid_ids is not None:
             new_res_map = {}

--- a/bucketmanager.py
+++ b/bucketmanager.py
@@ -9,7 +9,7 @@ def get_prng(seed):
     return np.random.RandomState(seed)
 
 class BucketManager:
-    def __init__(self, bucket_file, valid_ids=None, max_size=(512,512), divisible=16, step_size=8, min_dim=256, base_res=(512,512), bsz=64, world_size=1, global_rank=0, max_ar_error=4, seed=42, dim_limit=1024, debug=False):
+    def __init__(self, bucket_file, valid_ids=None, max_size=(768,512), divisible=64, step_size=8, min_dim=256, base_res=(512,512), bsz=64, world_size=1, global_rank=0, max_ar_error=4, seed=42, dim_limit=1024, debug=False):
         with open(bucket_file, "r") as fh:
             self.res_map = json.load(fh)
         if valid_ids is not None:

--- a/bucketmanager.py
+++ b/bucketmanager.py
@@ -9,7 +9,7 @@ def get_prng(seed):
     return np.random.RandomState(seed)
 
 class BucketManager:
-    def __init__(self, bucket_file, valid_ids=None, max_size=(768,512), divisible=64, step_size=8, min_dim=256, base_res=(512,512), bsz=64, world_size=1, global_rank=0, max_ar_error=4, seed=42, dim_limit=1024, debug=False):
+    def __init__(self, bucket_file, valid_ids=None, max_size=(768,512), divisible=64, step_size=8, min_dim=256, base_res=(512,512), bsz=1, world_size=1, global_rank=0, max_ar_error=4, seed=42, dim_limit=1024, debug=False):
         with open(bucket_file, "rb") as fh:
             self.res_map = pickle.load(fh)
         if valid_ids is not None:

--- a/bucketmanager.py
+++ b/bucketmanager.py
@@ -11,7 +11,7 @@ def get_prng(seed):
 class BucketManager:
     def __init__(self, bucket_file, valid_ids=None, max_size=(768,512), divisible=64, step_size=8, min_dim=256, base_res=(512,512), bsz=64, world_size=1, global_rank=0, max_ar_error=4, seed=42, dim_limit=1024, debug=False):
         with open(bucket_file, "rb") as fh:
-            self.res_map = json.load(fh)
+            self.res_map = pickle.load(fh)
         if valid_ids is not None:
             new_res_map = {}
             valid_ids = set(valid_ids)


### PR DESCRIPTION
leftover images from different buckets were being mixed, resulting in batches with inconsistent resolutions and incorrect batch sizes (e.g., 66 or 62 instead of the intended 64).